### PR TITLE
(work in progress)Check cache for valid data from nested provider

### DIFF
--- a/rcsb/utils/targets/CARDTargetAnnotationProvider.py
+++ b/rcsb/utils/targets/CARDTargetAnnotationProvider.py
@@ -90,7 +90,13 @@ class CARDTargetAnnotationProvider(StashableBase):
         """
         rDL = []
         cardP = CARDTargetProvider(cachePath=self.__cachePath, useCache=False)
+        if not cardP.testCache():
+            logger.warning("Skipping build of polymer entity annotation list because CARD Target data is missing.")
+            return False
         ontologyP = CARDTargetOntologyProvider(cachePath=self.__cachePath, useCache=False)
+        if not ontologyP.testCache():
+            logger.warning("Skipping build of polymer entity annotation list because CARD Target Ontology data is missing.")
+            return False
         mD = self.__mU.doImport(sequenceMatchFilePath, fmt="json")
         #
         refScheme = "PDB entity"

--- a/rcsb/utils/targets/ChEMBLTargetActivityProvider.py
+++ b/rcsb/utils/targets/ChEMBLTargetActivityProvider.py
@@ -131,10 +131,8 @@ class ChEMBLTargetActivityProvider(StashableBase):
         logger.info("ChEMBL API MAX_LIMIT %r", Settings.Instance().MAX_LIMIT)  # pylint: disable=no-member
         self.__aD, self.__allIdD = self.__reload(self.__dirPath, useCache)
 
-    def testCache(self, minCount=0):
-        if minCount == 0:
-            return True
-        if self.__aD and (len(self.__aD) > minCount):
+    def testCache(self, minCount=1):
+        if self.__aD and (len(self.__aD) >= minCount):
             logger.info("Activity data cached for (%d) targets", len(self.__aD))
             return True
         return False

--- a/rcsb/utils/targets/ChEMBLTargetCofactorProvider.py
+++ b/rcsb/utils/targets/ChEMBLTargetCofactorProvider.py
@@ -119,8 +119,14 @@ class ChEMBLTargetCofactorProvider(StashableBase):
         mD = self.__mU.doImport(sequenceMatchFilePath, fmt="json")
         #
         chP = ChEMBLTargetProvider(cachePath=self.__cachePath, useCache=False)
+        if not chP.testCache(1):
+            logger.warning("Skipping build of target cofactor list because ChEMBL Target data is missing.")
+            return False
         # ---
         chaP = ChEMBLTargetActivityProvider(cachePath=self.__cachePath, useCache=True)
+        if not chaP.testCache(1):
+            logger.warning("Skipping build of target cofactor list because ChEMBL Target Activity data is missing.")
+            return False
         #
         provenanceSource = "ChEMBL"
         refScheme = "PDB entity"

--- a/rcsb/utils/targets/DrugBankTargetCofactorProvider.py
+++ b/rcsb/utils/targets/DrugBankTargetCofactorProvider.py
@@ -92,6 +92,9 @@ class DrugBankTargetCofactorProvider(StashableBase):
         """
         rDL = []
         dbP = DrugBankTargetProvider(cachePath=self.__cachePath, useCache=True)
+        if not dbP.testCache():
+            logger.warning("Skipping build of target cofactor list because DrugBank Target data is missing.")
+            return False
         mD = self.__mU.doImport(sequenceMatchFilePath, fmt="json")
         #
         provenanceSource = "DrugBank"

--- a/rcsb/utils/targets/IMGTTargetFeatureProvider.py
+++ b/rcsb/utils/targets/IMGTTargetFeatureProvider.py
@@ -152,6 +152,9 @@ class IMGTTargetFeatureProvider(StashableBase):
         """
         rDL = []
         imgtP = IMGTTargetProvider(cachePath=self.__cachePath, useCache=useCache)
+        if not imgtP.testCache():
+            logger.warning("Skipping build of polymer instance feature list because IMGT Target data is missing.")
+            return False
         #
         provenanceSource = "IMGT"
         refScheme = "PDB entity"

--- a/rcsb/utils/targets/PharosTargetCofactorProvider.py
+++ b/rcsb/utils/targets/PharosTargetCofactorProvider.py
@@ -116,6 +116,9 @@ class PharosTargetCofactorProvider(StashableBase):
         mD = self.__mU.doImport(sequenceMatchFilePath, fmt="json")
         # ---
         chaP = PharosTargetActivityProvider(cachePath=self.__cachePath, useCache=True)
+        if not chaP.testCache(1):
+            logger.warning("Skipping build of target cofactor list because Pharos Target Activity data is missing.")
+            return False
         #
         provenanceSource = "Pharos"
         refScheme = "PDB entity"

--- a/rcsb/utils/targets/SAbDabTargetFeatureProvider.py
+++ b/rcsb/utils/targets/SAbDabTargetFeatureProvider.py
@@ -131,6 +131,9 @@ class SAbDabTargetFeatureProvider(StashableBase):
         """
         rDL = []
         stP = SAbDabTargetProvider(cachePath=self.__cachePath, useCache=False)
+        if not stP.testCache():
+            logger.warning("Skipping build of polymer entity feature list because SAbDab Target data is missing.")
+            return False
         mD = self.__mU.doImport(sequenceMatchFilePath, fmt="json")
         #
         provenanceSource = "SAbDab"


### PR DESCRIPTION
For some of these providers, the nested provider's data is not populated. It is therefore not valid to use them as a basis for the current provider. The idea is to return False if the nested provider testCache returns False.

Note: I have not done extensive testing of this. Also, there might be existing providers or places in these providers that need similar. 

This commit (https://github.com/rcsb/py-rcsb_utils_targets/pull/18/commits/d908fda54626c073a18d9130d4ac0d935c7d5c1c) is a suggestion to fix the tests. The test failed because the test data only has 1 item and testCache was checking > minCount. I think minCount should be inclusive.

See also https://github.com/rcsb/py-rcsb_workflow/pull/12